### PR TITLE
Fix modal body background color

### DIFF
--- a/sass/components/modal.sass
+++ b/sass/components/modal.sass
@@ -7,7 +7,7 @@ $modal-card-title-color-dark: $text-strong-dark !default
 
 $modal-card-foot-border-top-dark: 1px solid $border-dark !default
 
-$modal-card-body-background-color-dark: $white !default
+$modal-card-body-background-color-dark: $background-dark !default
 
 .modal-background
   background-color: $modal-background-background-color-dark


### PR DESCRIPTION
I'm not sure if this is on purpose, but the modal body background color was white instead of dark. This fixes it so it looks correct.